### PR TITLE
:green_heart: don't allow installing a package that's already installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "webpack-cli": "^3.1.0"
   },
   "dependencies": {
+    "app-exists": "^1.0.0",
+    "app-path": "^3.2.0",
     "axios": "^0.19.0",
     "execa": "^3.2.0",
     "inquirer": "^7.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -140,14 +140,12 @@ async function installRequirement({ check, force = false, name, install }) {
 }
 
 async function promptInstallPackages(packageBundles) {
-  const choices = Object.entries(packageBundles).reduce(
-    (allChoices, [name, packages]) => [
-      ...allChoices,
+  const choices = (await Promise.all(
+    Object.entries(packageBundles).flatMap(async ([name, packages]) => [
       new inquirer.Separator('\n' + name.toUpperCase()),
-      ...packages
-    ],
-    []
-  );
+      ...(await packages())
+    ])
+  )).flatMap(section => section);
 
   const answers = await inquirer.prompt([
     {

--- a/src/packages/alreadyInstalled.js
+++ b/src/packages/alreadyInstalled.js
@@ -1,0 +1,18 @@
+import appPath from 'app-path';
+
+/**
+ * Check if an app is installed or not.
+ * @param {String} appName App name or bundle identifier
+ * @return {Boolean|String} The path to the installed app if it was found.
+ * Otherwise, returns `false`.
+ */
+async function alreadyInstalled(appName) {
+  try {
+    const installPath = await appPath(appName);
+    return `Already installed at ${installPath}`;
+  } catch (error) {
+    return false;
+  }
+}
+
+export default alreadyInstalled;

--- a/src/packages/browsers.js
+++ b/src/packages/browsers.js
@@ -1,8 +1,19 @@
+import alreadyInstalled from './alreadyInstalled';
 import { brewCaskInstall } from './installers';
 
-export default [
+export default async () => [
   {
     checked: true,
+    disabled: await alreadyInstalled('Brave Browser'),
+    name: 'Brave',
+    value: {
+      install: brewCaskInstall('brave-browser'),
+      name: 'Brave'
+    }
+  },
+  {
+    checked: true,
+    disabled: await alreadyInstalled('Firefox'),
     name: 'Firefox',
     value: {
       install: brewCaskInstall('firefox'),
@@ -11,6 +22,7 @@ export default [
   },
   {
     checked: false,
+    disabled: await alreadyInstalled('Firefox Developer Edition'),
     name: 'Firefox Developer Edition',
     value: {
       install: brewCaskInstall('firefox-developer-edition'),
@@ -19,6 +31,7 @@ export default [
   },
   {
     checked: true,
+    disabled: await alreadyInstalled('Google Chrome'),
     name: 'Google Chrome',
     value: {
       install: brewCaskInstall('google-chrome'),
@@ -27,6 +40,7 @@ export default [
   },
   {
     checked: false,
+    disabled: await alreadyInstalled('Google Chrome Canary'),
     name: 'Google Chrome Canary',
     value: {
       install: brewCaskInstall('google-chrome-canary'),

--- a/src/packages/editors.js
+++ b/src/packages/editors.js
@@ -1,8 +1,10 @@
 import { brewCaskInstall } from './installers';
+import alreadyInstalled from './alreadyInstalled';
 
-export default [
+export default async () => [
   {
-    checked: true,
+    checked: false,
+    disabled: await alreadyInstalled('Atom'),
     name: 'Atom',
     value: {
       install: brewCaskInstall('atom'),
@@ -11,6 +13,7 @@ export default [
   },
   {
     checked: false,
+    disabled: await alreadyInstalled('Sublime Text'),
     name: 'Sublime Text',
     value: {
       install: brewCaskInstall('sublime-text'),
@@ -19,6 +22,7 @@ export default [
   },
   {
     checked: true,
+    disabled: await alreadyInstalled('Visual Studio Code'),
     name: 'Visual Studio Code',
     value: {
       install: brewCaskInstall('visual-studio-code'),

--- a/src/packages/extras.js
+++ b/src/packages/extras.js
@@ -1,8 +1,11 @@
+import foundInPath from '../foundInPath';
+import alreadyInstalled from './alreadyInstalled';
 import { brewCaskInstall, npmGlobalInstall } from './installers';
 
-export default [
+export default async () => [
   {
-    checked: false,
+    checked: true,
+    disabled: await alreadyInstalled('Insomnia'),
     name: 'Insomnia (https://insomnia.rest)',
     value: {
       install: brewCaskInstall('insomnia'),
@@ -11,6 +14,7 @@ export default [
   },
   {
     checked: false,
+    disabled: await alreadyInstalled('Kitematic (Beta)'),
     name: 'Kitematic (https://kitematic.com)',
     value: {
       install: brewCaskInstall('kitematic'),
@@ -19,6 +23,7 @@ export default [
   },
   {
     checked: false,
+    disabled: await alreadyInstalled('Mojibar'),
     name: 'Mojibar (https://github.com/muan/mojibar)',
     value: {
       install: brewCaskInstall('mojibar'),
@@ -27,6 +32,7 @@ export default [
   },
   {
     checked: false,
+    disabled: await alreadyInstalled('Postman'),
     name: 'Postman (https://www.getpostman.com)',
     value: {
       install: brewCaskInstall('postman'),
@@ -35,6 +41,7 @@ export default [
   },
   {
     checked: false,
+    disabled: await alreadyInstalled('Sequel Pro'),
     name: 'Sequel Pro (https://www.sequelpro.com)',
     value: {
       install: brewCaskInstall('sequel-pro'),
@@ -43,6 +50,7 @@ export default [
   },
   {
     checked: true,
+    disabled: await foundInPath('serve'),
     name: 'serve (https://github.com/zeit/serve)',
     value: {
       install: npmGlobalInstall('serve'),
@@ -51,6 +59,7 @@ export default [
   },
   {
     checked: true,
+    disabled: await alreadyInstalled('Slack'),
     name: 'Slack (https://slack.com/)',
     value: {
       install: brewCaskInstall('slack'),
@@ -59,6 +68,7 @@ export default [
   },
   {
     checked: false,
+    disabled: await alreadyInstalled('Sqlectron'),
     name: 'Sqlectron (https://sqlectron.github.io/)',
     value: {
       install: brewCaskInstall('sqlectron'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -953,6 +953,20 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
+app-exists@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/app-exists/-/app-exists-1.0.0.tgz#0f689873c7de9d3a3b5172ea813e889f00cf144e"
+  integrity sha512-9d8UBBgOmFQFCrUDc74J/7I868l8Fsy9zQpmtEzuP6vBCB3bykkMbBKKCNf3096JN2UgsJkwWQ7qEj2PyUJHEw==
+  dependencies:
+    run-applescript "^3.1.0"
+
+app-path@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/app-path/-/app-path-3.2.0.tgz#06d426e0c988885264e0aa0a766dfa2723491633"
+  integrity sha512-PQPaKXi64FZuofJkrtaO3I5RZESm9Yjv7tkeJaDz4EZMeBBfGtr5MyQ3m5AC7F0HVrISBLatPxAAAgvbe418fQ==
+  dependencies:
+    execa "^1.0.0"
+
 aproba@^1.0.3, aproba@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
@@ -2130,6 +2144,19 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
 
+execa@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.10.0.tgz#ff456a8f53f90f8eccc71a96d11bdfc7f082cb50"
+  integrity sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==
+  dependencies:
+    cross-spawn "^6.0.0"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
 execa@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-1.0.0.tgz#c6236a5bb4df6d6f15e88e7f017798216749ddd8"
@@ -2472,6 +2499,11 @@ get-caller-file@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
+get-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+  integrity sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=
 
 get-stream@^4.0.0:
   version "4.0.0"
@@ -4483,6 +4515,13 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
+
+run-applescript@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/run-applescript/-/run-applescript-3.2.0.tgz#73fb34ce85d3de8076d511ea767c30d4fdfc918b"
+  integrity sha512-Ep0RsvAjnRcBX1p5vogbaBdAGu/8j/ewpvGqnQYunnLd9SM0vWcPJewPKNnWFggf0hF0pwIgwV5XK7qQ7UZ8Qg==
+  dependencies:
+    execa "^0.10.0"
 
 run-async@^2.2.0:
   version "2.3.0"


### PR DESCRIPTION
At the end of the script, optional extras could be selected for installation. However, if one of those were already installed, this would cause a crash.

This fixes that by disabling those from being installed.